### PR TITLE
Replace useEffect with useLayoutEffect

### DIFF
--- a/src/useBreakpoints.js
+++ b/src/useBreakpoints.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useLayoutEffect } from 'react';
 import { useResizeObserverEntry } from './useResizeObserverEntry';
 
 const boxOptions = {
@@ -74,7 +74,7 @@ const useBreakpoints = ({
     }
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setWidth(findBreakpoint(widths, entryWidth));
     setHeight(findBreakpoint(heights, entryHeight));
   }, [widths, entryWidth, heights, entryHeight]);


### PR DESCRIPTION
## Context

`useBreakpoints` updates its internal state when the observed element's size changes. It currently does this via a `useEffect` callback function. But the function passed to `useEffect` [will run _after_ the render is committed to the screen](https://reactjs.org/docs/hooks-reference.html#useeffect). Because we are observing DOM mutations, it's better to use `useLayoutEffect`, as [updates scheduled inside `useLayoutEffect` will be flushed synchronously, before the browser has a chance to paint](https://reactjs.org/docs/hooks-reference.html#uselayouteffect).

## Changes

* Replace `useEffect` with `useLayoutEffect`. The hook signatures are identical.

## Considerations

* Callbacks inside `useLayoutEffect` can potentially block visual updates. But this is precisely our intention: we want `useBreakpoints`'s internal state to accurately reflect the current DOM mutation _before_ it's painted, _not after_. Setting the state after mutations occur could result in a (admittedly very brief) moment of returning incorrect values from `useBreakpoints`.