### PR TITLE
Fix first-render return values from useBreakpoints

### DIFF
--- a/src/useBreakpoints.js
+++ b/src/useBreakpoints.js
@@ -14,6 +14,8 @@ const boxOptions = {
  * @returns {*} Value of `breakpoints` at matching breakpoint.
  */
 const findBreakpoint = (breakpoints, entrySize) => {
+  if (typeof entrySize === 'undefined') return undefined;
+
   let breakpoint;
   const sizes = Object.keys(breakpoints);
 


### PR DESCRIPTION
## Context

When `<Observe>` mounts, it calls [`useResizeObserver`](https://github.com/envato/react-resize-observer-hook). That returns `[ref, observedEntry]`, where the `ref` is used to appoint an element rendered by `<Observe>` for observation. This means the observation hasn't happened yet, and so, naturally, `observedEntry` is `undefined` during this first render.

`<Observe>` puts this value on a context, and it also uses it internally for when a user uses the `breakpoints` prop.

Now, any `useBreakpoints` calls, including the one inside `<Observe>` itself, consume `undefined` as the value for `observedEntry`. So far, all of this is intentional.

When `useBreakpoints` attempts to find a breakpoint using `undefined` as the reference value, we intend to return `undefined`. This is so that users of `useBreakpoints` can assign default values or bail out of rendering, or employ other strategies to deal with scenarios like Server-Side Rendering.

```javascript
const [widthMatch, heightMatch] = useBreakpoints({
  widths: {
    0: 'mobile',
    426: 'tablet',
    769: 'laptop',
    1025: 'desktop',
    1441: 'widescreen'
  },
  heights: {
    480: 'SD',
    720: 'HD Ready',
    1080: 'Full HD',
    2160: '4K'
  }
);
// widthMatch = 'widescreen'
// heightMatch = '4K'
```
The problem is that `useBreakpoints(options)` is currently **not** returning `[undefined, undefined]`, it is returning the value of the last keys in `options.widths` and `options.heights`. This is because an `observedEntry = undefined` does not trigger the condition in `findBreakpoint`:

https://github.com/envato/react-breakpoints/blob/a4fd8d305886820e2e60a9b292dee5d63b7876fc/src/useBreakpoints.js#L16-L26

This causes the loop to keep stepping until it reached the final key, which is eventually returned.

## Changes

* Short-circuit `findBreakpoints(breakpoints, entrySize)` when the `entrySize` is `undefined`.