### PR TITLE
Add TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.2",
   "description": "Respond to changes in a DOM element's size. With React Breakpoints, element queries are no longer \"web design's unicorn\" 🦄",
   "main": "dist/index.js",
+  "types": "src/index.d.ts",
   "scripts": {
     "build": "babel src/ -d dist/ --source-maps",
     "prepare": "npm run build"

--- a/src/Observe.js
+++ b/src/Observe.js
@@ -4,9 +4,9 @@ import { Context } from './Context';
 import { useBreakpoints } from './useBreakpoints';
 
 const Observe = ({
-  render,
   box = undefined,
-  breakpoints = {}
+  breakpoints = {},
+  render
 }) => {
   const observeOptions = box ? { box } : {};
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,55 @@
+import React from 'react';
+
+type BoxOptions = 'border-box' | 'content-box' | 'device-pixel-content-box';
+
+interface ResizeObserverBoxSize {
+  readonly inlineSize: number;
+  readonly blockSize: number;
+}
+
+interface ResizeObserverEntry {
+  readonly target: Element;
+  readonly contentRect: DOMRectReadOnly;
+  readonly borderBoxSize: Array<ResizeObserverBoxSize> | ResizeObserverBoxSize;
+  readonly contentBoxSize: Arrray<ResizeObserverBoxSize> | ResizeObserverBoxSize;
+  readonly devicePixelContentBoxSize: Arrray<ResizeObserverBoxSize> | ResizeObserverBoxSize;
+}
+
+interface Breakpoints<T> {
+  [key: number]: T;
+}
+
+interface BreakpointsOptions<W, H> {
+  box?: BoxOptions;
+  widths?: Breakpoints<W>;
+  heights?: Breakpoints<H>;
+  fragment?: number;
+}
+
+interface ObservedElementProps<T> {
+  ref: React.RefObject<T>;
+}
+
+interface ObserveRenderArgs<E, W, H> {
+  observedElementProps: ObservedElementProps<E>;
+  widthMatch: W;
+  heightMatch: H;
+}
+
+interface ObserveProps<E, W, H> {
+  box?: BoxOptions;
+  breakpoints?: BreakpointsOptions<W, H>;
+  render: ({
+    observedElementProps,
+    widthMatch,
+    heightMatch
+  }: ObserveRenderArgs<E, W, H>) => JSX.Element;
+}
+
+export const Observe: <E, W, H>(props: ObserveProps<E, W, H>) => JSX.Element;
+
+export const useBreakpoints: <W extends any, H extends any>(options: BreakpointsOptions<W, H>) => [W, H];
+
+export const useResizeObserverEntry: (injectResizeObserverEntry?: ResizeObserverEntry) => ResizeObserverEntry | null;
+
+export const Context: React.Context<ResizeObserverEntry | null>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,44 +11,44 @@ interface ResizeObserverEntry {
   readonly target: Element;
   readonly contentRect: DOMRectReadOnly;
   readonly borderBoxSize: Array<ResizeObserverBoxSize> | ResizeObserverBoxSize;
-  readonly contentBoxSize: Arrray<ResizeObserverBoxSize> | ResizeObserverBoxSize;
-  readonly devicePixelContentBoxSize: Arrray<ResizeObserverBoxSize> | ResizeObserverBoxSize;
+  readonly contentBoxSize: Array<ResizeObserverBoxSize> | ResizeObserverBoxSize;
+  readonly devicePixelContentBoxSize: Array<ResizeObserverBoxSize> | ResizeObserverBoxSize;
 }
 
-interface Breakpoints<T> {
-  [key: number]: T;
+interface Breakpoints {
+  [key: number]: any;
 }
 
-interface BreakpointsOptions<W, H> {
+interface BreakpointsOptions {
   box?: BoxOptions;
-  widths?: Breakpoints<W>;
-  heights?: Breakpoints<H>;
+  widths?: Breakpoints;
+  heights?: Breakpoints;
   fragment?: number;
 }
 
-interface ObservedElementProps<T> {
-  ref: React.RefObject<T>;
+interface ObservedElementProps {
+  ref: () => React.RefObject<HTMLElement>;
 }
 
-interface ObserveRenderArgs<E, W, H> {
-  observedElementProps: ObservedElementProps<E>;
-  widthMatch: W;
-  heightMatch: H;
+interface ObserveRenderArgs {
+  observedElementProps: ObservedElementProps;
+  widthMatch: any;
+  heightMatch: any;
 }
 
-interface ObserveProps<E, W, H> {
+interface ObserveProps {
   box?: BoxOptions;
-  breakpoints?: BreakpointsOptions<W, H>;
+  breakpoints?: BreakpointsOptions;
   render: ({
     observedElementProps,
     widthMatch,
     heightMatch
-  }: ObserveRenderArgs<E, W, H>) => JSX.Element;
+  }: ObserveRenderArgs) => React.ReactNode;
 }
 
-export const Observe: <E, W, H>(props: ObserveProps<E, W, H>) => JSX.Element;
+export const Observe: (props: ObserveProps) => React.ReactNode;
 
-export const useBreakpoints: <W extends any, H extends any>(options: BreakpointsOptions<W, H>) => [W, H];
+export const useBreakpoints: (options: BreakpointsOptions, injectResizeObserverEntry?: ResizeObserverEntry) => [any, any];
 
 export const useResizeObserverEntry: (injectResizeObserverEntry?: ResizeObserverEntry) => ResizeObserverEntry | null;
 


### PR DESCRIPTION
## Disclaimer

I'm not fluent in TypeScript and I'm relying on the experience of my co-workers to check that these definitions are correct. To help with reviewing, for those who aren't sure what _exactly_ this package does under the hood, I've added some comments below.

## Context

This package is not written in TypeScript, and I'm currently not planning on rewriting it because I don't have enough experience in TS. However, many people do use TS and I want to make it easier for them to use this package.

Providing a definitions file seems like a nice middle ground.

## Changes

* Adds a TypeScript definitions file.

## Considerations

* Now that `ResizeObserver` is implemented in Safari, microsoft/TypeScript#37861 has started moving forward. Unsure what the exact impact will be on this package, but I assume I'll no longer need to manually specify interfaces for `ResizeObserverBoxSize`, `ResizeObserverEntry`, etc.