### PR TITLE
Reduce rerendering caused by resize observations

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "@envato/react-resize-observer-hook": "^1.0.1"
+    "@envato/react-resize-observer-hook": "^1.0.1",
+    "just-compare": "^1.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react-dom": "^16.12.0"
   },
   "dependencies": {
-    "@envato/react-resize-observer-hook": "^1.0.1",
-    "just-compare": "^1.3.0"
+    "@envato/react-resize-observer-hook": "^1.0.1"
   }
 }

--- a/src/useBreakpoints.js
+++ b/src/useBreakpoints.js
@@ -1,5 +1,6 @@
-import { useState, useLayoutEffect } from 'react';
+import { useRef, useState, useLayoutEffect } from 'react';
 import { useResizeObserverEntry } from './useResizeObserverEntry';
+import compare from 'just-compare';
 
 const boxOptions = {
   BORDER_BOX: 'border-box', // https://caniuse.com/#feat=mdn-api_resizeobserverentry_borderboxsize
@@ -45,6 +46,9 @@ const useBreakpoints = ({
 }, injectResizeObserverEntry = undefined) => {
   const resizeObserverEntry = useResizeObserverEntry(injectResizeObserverEntry);
 
+  const widthRef = useRef(undefined);
+  const heightRef = useRef(undefined);
+
   const [width, setWidth] = useState(undefined);
   const [height, setHeight] = useState(undefined);
 
@@ -77,8 +81,18 @@ const useBreakpoints = ({
   }
 
   useLayoutEffect(() => {
-    setWidth(findBreakpoint(widths, entryWidth));
-    setHeight(findBreakpoint(heights, entryHeight));
+    const widthMatch = findBreakpoint(widths, entryWidth);
+    const heightMatch = findBreakpoint(heights, entryHeight);
+
+    if (!compare(widthMatch, widthRef.current)) {
+      widthRef.current = widthMatch;
+      setWidth(widthMatch);
+    }
+
+    if (!compare(heightMatch, heightRef.current)) {
+      heightRef.current = heightMatch;
+      setHeight(heightMatch);
+    }
   }, [widths, entryWidth, heights, entryHeight]);
 
   return [width, height];

--- a/src/useBreakpoints.js
+++ b/src/useBreakpoints.js
@@ -1,6 +1,5 @@
 import { useRef, useState, useLayoutEffect } from 'react';
 import { useResizeObserverEntry } from './useResizeObserverEntry';
-import compare from 'just-compare';
 
 const boxOptions = {
   BORDER_BOX: 'border-box', // https://caniuse.com/#feat=mdn-api_resizeobserverentry_borderboxsize
@@ -12,7 +11,7 @@ const boxOptions = {
  * Find the breakpoint matching the given entry size.
  * @argument {Object} breakpoints - Map of sizes with their return values.
  * @argument {Number} entrySize - Size of entry to check breakpoints against.
- * @returns {*} Value of `breakpoints` at matching breakpoint.
+ * @returns {Number} Key of `breakpoints` at matching breakpoint.
  */
 const findBreakpoint = (breakpoints, entrySize) => {
   if (typeof entrySize === 'undefined') return undefined;
@@ -25,7 +24,7 @@ const findBreakpoint = (breakpoints, entrySize) => {
     breakpoint = next;
   }
 
-  return breakpoints[breakpoint];
+  return breakpoint;
 };
 
 /**
@@ -84,18 +83,18 @@ const useBreakpoints = ({
     const widthMatch = findBreakpoint(widths, entryWidth);
     const heightMatch = findBreakpoint(heights, entryHeight);
 
-    if (!compare(widthMatch, widthRef.current)) {
+    if (widthMatch !== widthRef.current) {
       widthRef.current = widthMatch;
       setWidth(widthMatch);
     }
 
-    if (!compare(heightMatch, heightRef.current)) {
+    if (heightMatch !== heightRef.current) {
       heightRef.current = heightMatch;
       setHeight(heightMatch);
     }
   }, [widths, entryWidth, heights, entryHeight]);
 
-  return [width, height];
+  return [widths[width], heights[height]];
 };
 
 export { useBreakpoints };


### PR DESCRIPTION
## Context

When a component's state changes, React will rerender it and its children. `useBreakpoints` uses `useState` internally to manage the observed breakpoints. For most breakpoints value types, I can rely on React to skip rerendering children if I update the state to the same value. However, `useBreakpoints` allows objects to be a returned value type, so these would trigger potentially unnecessary rerenders.

## Changes

* `findBreakpoint` now returns the key of the matching breakpoint rather than its value.
* Update state only if matched key is different than current state.