### PR TITLE
Remove state management from useBreakpoints

### DIFF
--- a/src/useBreakpoints.js
+++ b/src/useBreakpoints.js
@@ -1,4 +1,3 @@
-import { useState, useLayoutEffect } from 'react';
 import { useResizeObserverEntry } from './useResizeObserverEntry';
 
 const boxOptions = {
@@ -45,9 +44,6 @@ const useBreakpoints = ({
 }, injectResizeObserverEntry = undefined) => {
   const resizeObserverEntry = useResizeObserverEntry(injectResizeObserverEntry);
 
-  const [width, setWidth] = useState(undefined);
-  const [height, setHeight] = useState(undefined);
-
   let entryBox, entryWidth, entryHeight;
 
   if (resizeObserverEntry) {
@@ -76,12 +72,10 @@ const useBreakpoints = ({
     }
   }
 
-  useLayoutEffect(() => {
-    setWidth(findBreakpoint(widths, entryWidth));
-    setHeight(findBreakpoint(heights, entryHeight));
-  }, [widths, entryWidth, heights, entryHeight]);
+  const widthMatch = findBreakpoint(widths, entryWidth);
+  const heightMatch = findBreakpoint(heights, entryHeight);
 
-  return [width, height];
+  return [widthMatch, heightMatch];
 };
 
 export { useBreakpoints };


### PR DESCRIPTION
## Context

After suggesting #9 and the discussion and exploration that came from that, it slowly became clear that `useBreakpoints` doesn't actually need to handle state. It was there in an attempt to handle some optimisations for the user, but with the nature of re-rendering in React these weren't very good optimisations.

## Changes

* Remove state and side-effect management from `useBreakpoints()`.

## Considerations

* `Observe` and `useBreakpoints` **will make your components re-render on every resize observation**. If you only want to re-render them when breakpoint values actually change, use `useMemo` or `React.memo`.